### PR TITLE
Adding support for more negative testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ branches:
   except:
     - gh-pages
 
+before_install:
+    - if [[ `node --version` == *v0.8* ]]; then npm install -g npm; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Changelog
+---------
+
+<table>
+<tr><td>v0.2.2</td><td>Adding support for throwing an exception when the mock process is spawned. Documenting previously undocumented feature for emitting an error with the underlying eventemitter.</td></tr>
+<tr><td>v0.2.1</td><td>Initial version</td></tr>
+</td></tr>
+</table>

--- a/examples/complete/lib.js
+++ b/examples/complete/lib.js
@@ -2,17 +2,32 @@
  Copyright 2014 Yahoo! Inc. All rights reserved.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+'use strict';
 var spawn = require('child_process').spawn;
 
 module.exports = {
     run: function (command, args, cb) {
-        var proc = spawn(command, args);
+        var cbCalled = false,
+            proc;
+        try{
+            proc = spawn(command, args);
+        } catch(e){
+            return cb(e);
+        }
         proc.stdout.setEncoding('utf8');
         proc.stdout.on('data', function (d) { console.log(d); });
         proc.stderr.on('data', function (d) { console.error(d); });
         proc.on('exit', function (code) {
-            return cb(code === 0 ? null : new Error("Command exited: " + code));
+            if(!cbCalled){
+                cbCalled = true;
+                return cb(code === 0 ? null : new Error('Command exited: ' + code));
+            }
+        });
+        proc.on('error', function (e) {
+            if(!cbCalled){
+                cbCalled = true;
+                return cb(e);
+            }
         });
     }
 };
-

--- a/examples/simple/lib.js
+++ b/examples/simple/lib.js
@@ -2,18 +2,32 @@
  Copyright 2014 Yahoo! Inc. All rights reserved.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+'use strict';
 
 var child_process = require('child_process');
 
 module.exports = {
     run: function (command, args, cb) {
-        var proc = child_process.spawn(command, args);
+        var proc, cbCalled = false;
+        try{
+            proc = child_process.spawn(command, args);
+        } catch(e){
+            return cb(e);
+        }
         proc.stdout.setEncoding('utf8');
         proc.stdout.on('data', function (d) { console.log(d); });
         proc.stderr.on('data', function (d) { console.error(d); });
+        proc.on('error', function (e) {
+            if(!cbCalled){
+                cbCalled = true;
+                return cb(e);
+            }
+        });
         proc.on('exit', function (code) {
-            return cb(code === 0 ? null : new Error("Command exited: " + code));
+            if(!cbCalled){
+                cbCalled = true;
+                return cb(code === 0 ? null : new Error('Command exited: ' + code));
+            }
         });
     }
 };
-

--- a/examples/simple/test.js
+++ b/examples/simple/test.js
@@ -2,7 +2,7 @@
  Copyright 2014 Yahoo! Inc. All rights reserved.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-
+'use strict';
 var assert = require('assert'),
     child_process = require('child_process'),
     mockSpawn = require('../../index'),
@@ -19,3 +19,33 @@ lib.run('echo', [ 'hello', 'world' ], function (err) {
     console.log('tests passed!');
 });
 
+var cbcalled = false;
+spawn.sequence.add(function(cb){
+    this.emit('error', new Error('spawn ENOENT'));
+    process.nextTick(function(){
+        cb(-1);
+        cbcalled = true;
+    });
+});
+
+lib.run('echo2', ['Hello','World'],function(err) {
+    assert(err);
+    assert.equal(err.message,'spawn ENOENT');
+    var call = spawn.calls[1];
+    assert.equal(call.command, 'echo2');
+    assert.deepEqual(call.args, ['Hello','World']);
+    assert(!cbcalled);
+    console.log('emit strategy worked!');
+});
+
+
+spawn.sequence.add({throws:new Error('spawn ENOENT')});
+
+lib.run('echo3', ['Hello','World'],function(err) {
+    assert(err);
+    assert.equal(err.message,'spawn ENOENT');
+    var call = spawn.calls[2];
+    assert.equal(call.command, 'echo3');
+    assert.deepEqual(call.args, ['Hello','World']);
+    console.log('throw strategy worked!');
+});

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
 Copyright 2014 Yahoo! Inc. All rights reserved.
 Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
@@ -32,7 +33,8 @@ function MockProcess(runner) {
 util.inherits(MockProcess, EventEmitter);
 
 MockProcess.prototype._start = function (command, args, opts) {
-    var that = this;
+    var that = this,
+        runner = this._runner;
 
     this.command = command;
     this.args = args;
@@ -40,8 +42,10 @@ MockProcess.prototype._start = function (command, args, opts) {
     this.pid = lastPid;
     lastPid += 1;
 
+    if(runner.throws instanceof Error){
+        throw runner.throws;
+    }
     process.nextTick(function () {
-        var runner = that._runner;
         runner.call(that, function (exitCode, signal) {
             that.exitCode = exitCode;
             if (signal) {
@@ -146,7 +150,7 @@ module.exports = function (verbose) {
 
     main.__defineGetter__('sequence', function () { return pm.sequence; });
     main.__defineGetter__('calls', function () { return pm.calls.slice(); });
-    main.setDefault = function (fn) { pm.defaultFn  = fn; };
+    main.setDefault = function (fn) { pm.defaultFn = fn; };
     main.setStrategy = function (s) { pm.setStrategy(s); };
     main.simple = function (exitCode, stdout, stderr) {
         return ezRunner(exitCode, stdout, stderr).setVerbose(verbose);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
     "name": "mock-spawn",
     "description": "A mock for child_process.spawn",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "keywords": [ "child_process", "child process", "spawn", "mock" ],
     "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
-    "contributors": [],
+    "contributors": [
+        "Greg Cochard <greg.cochard@gmail.com>"
+    ],
     "repository": {
         "type": "git",
         "url": "git://github.com/gotwarlost/mock-spawn.git"


### PR DESCRIPTION
spawn can (and does) throw errors. ChildProcess also emits errors. In order to test for these edge cases, it is necessary to have mock-spawn mimic this behavior. I have added the ability to throw an error, and I have added testing for the ability to emit an error as well (the behavior was already there but undocumented).
