### PR TITLE
Don't output things to console while not in verbose mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function makeSeq(verbose) {
                         ' remaining functions');
                 }
                 runner = runners.shift();
-            } else {
+            } else if (verbose) {
                 console.log('No runners left, using default');
             }
             return runner;


### PR DESCRIPTION
In my use case, I don't need to add runners to the sequence in every test case, relaying on default very often.
This avoids ''No runners left, using default'' in the test output unless specified

Great job!!!
  
