### PR TITLE
Add support for process.kill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
-  - "0.11"
-
-matrix:
-  allow_failures:
-    - node_js: "0.11"
+  - "0.12"
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,8 @@ branches:
 
 before_install:
     - if [[ `node --version` == *v0.8* ]]; then npm install -g npm; fi
+
+sudo: false
+cache:
+  directories:
+    - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Changelog
 ---------
 
 <table>
+<tr><td>v0.2.4</td><td>Add preliminary support for `child_process.kill`.</td></tr>
+<tr><td>v0.2.3</td><td>Use v10 Passthrough streams to avoid bugs due to assumptions by stream wrappers.</td></tr>
 <tr><td>v0.2.2</td><td>Adding support for throwing an exception when the mock process is spawned. Documenting previously undocumented feature for emitting an error with the underlying eventemitter.</td></tr>
 <tr><td>v0.2.1</td><td>Initial version</td></tr>
-</td></tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ sets `fn` as the strategy that will return runner functions on demand.
 
 Do **not** mix `sequence.add` and `setStrategy` calls for a specific run.
 
+#### mySpawn.setSignals(obj)
+
+sets `obj` as a lookup table for whether to exit. If the value is `true`,
+then the runner will emit `exit` with code `null` and signal `<signal>`.
+
+* obj - the object with signal names and whether to exit.
+
 #### mySpawn.calls
 
 array of mock process objects that you can use to inspect how your library
@@ -199,6 +206,6 @@ The following third-party libraries are used by this module:
 Pull requests welcome!
 
  * `child_process.fork` and `child_process.exec` processing
- * reasonable behavior on `process.kill`
+ * strategy functions on `process.kill`
 
 

--- a/examples/complete/lib.js
+++ b/examples/complete/lib.js
@@ -17,9 +17,12 @@ module.exports = {
         proc.stdout.setEncoding('utf8');
         proc.stdout.on('data', function (d) { console.log(d); });
         proc.stderr.on('data', function (d) { console.error(d); });
-        proc.on('exit', function (code) {
+        proc.on('exit', function (code, sig) {
             if(!cbCalled){
                 cbCalled = true;
+                if(sig){
+                    return cb(new Error(sig));
+                }
                 return cb(code === 0 ? null : new Error('Command exited: ' + code));
             }
         });
@@ -29,5 +32,6 @@ module.exports = {
                 return cb(e);
             }
         });
+        return proc;
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mock-spawn",
     "description": "A mock for child_process.spawn",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "keywords": [ "child_process", "child process", "spawn", "mock" ],
     "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
     "contributors": [


### PR DESCRIPTION
Adding `child_process.kill` support. It will let you define signals as keys, and a boolean indicator for whether to exit on receipt of the signal.

Also adding node v0.12 to the travis tests.

Also moving travis to container-based build, which is [much faster](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/), and caching the `node_modules` directory to increase speed too.