### PR TITLE
Race condition in node 0.8.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ MockProcess.prototype._start = function (command, args, opts) {
     if(runner.throws instanceof Error){
         throw runner.throws;
     }
+    this.stdin.pause();
     process.nextTick(function () {
         runner.call(that, function (exitCode) {
             if(!that.ended){
@@ -71,6 +72,7 @@ MockProcess.prototype._start = function (command, args, opts) {
                 that.stderr.end();
             }
         });
+        that.stdin.resume();
     });
     return this;
 };


### PR DESCRIPTION
Hi.

I found a race condition in `mock-spawn` that affects node 0.8.x users.

Consider the following code:

```js
var mockSpawn = require('mock-spawn')
  , mySpawn = mockSpawn();

mySpawn.setDefault(function(done) {
  this.stdin.on('data', function(chunk) {
    console.log('data:', String(chunk));
  });
  this.stdin.on('end', function() {
    console.log('end!');
    done(0);
  });
});

var proc = mySpawn();

proc.once('close', function(code) {
  console.log('Ended with code', code);
});

proc.stdin.end('Hello world!');
```

It should print something like

```
data: Hello world!
end!
```

But in node 0.8.x data gets emitted before `mySpawn` handler function is called, so nothing got printed.

This bug can only be reproduced in node 0.8.x, because of a new streaming API that was introduced in node 0.10.x and took care of things like that.