### PR TITLE
Default signal - SIGTERM

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ MockProcess.prototype._start = function (command, args, opts) {
 };
 
 MockProcess.prototype.kill = function (signal) {
+    signal = signal || 'SIGTERM';
     var that = this;
     // if the signals object contains this signal and is *truthy*, and it is still running, exit
     if(this.signals[signal]){


### PR DESCRIPTION
`process.kill` uses `SIGTERM` as the default signal when none is passed. This behavior was not mocked properly, this PR fixes that issue.