### PR TITLE
Fix code type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mySpawn.sequence.add(function (cb) {
 });
 mySpawn.sequence.add(function (cb) {
     // test the error handling of your library
-    this.emit('error', new Error('spawn ENOENT');
+    this.emit('error', new Error('spawn ENOENT'));
     setTimeout(function() { return cb(8); }, 10);
 });
 mySpawn.sequence.add({throws:new Error('spawn ENOENT')});


### PR DESCRIPTION
If you copy-paste this line, it will not run since it's missing a closing parenthesis. Pretty sure it is a typo.

Unless of course it is intended, in which case you are free to ignore this :)