### PR TITLE
Support for unref()

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,8 @@ MockProcess.prototype._start = function (command, args, opts) {
     return this;
 };
 
+MockProcess.prototype.unref = function () {}
+
 MockProcess.prototype.kill = function (signal) {
     signal = signal || 'SIGTERM';
     var that = this;

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ MockProcess.prototype._start = function (command, args, opts) {
     return this;
 };
 
-MockProcess.prototype.unref = function () { return this; }
+MockProcess.prototype.unref = function () { return this; };
 
 MockProcess.prototype.kill = function (signal) {
     signal = signal || 'SIGTERM';

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ MockProcess.prototype._start = function (command, args, opts) {
     return this;
 };
 
-MockProcess.prototype.unref = function () {}
+MockProcess.prototype.unref = function () { return this; }
 
 MockProcess.prototype.kill = function (signal) {
     signal = signal || 'SIGTERM';


### PR DESCRIPTION
Support for `process.unref()`.
Returns the process itself for chaining process functions.

Correct me if I'm wrong, but I don't think there's any special handling required in the mocked version.